### PR TITLE
Updated filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ idam-pr:
 ```
 *Notes*: 
 - idam-pr.service.name: name of the service as configured in IDAM. It is unique per service per environment and will 
-match the label your service appears with in IDAM Admin Console. If you are not sure what it  needs to be set to, 
-please contact IDAM team at #sidam-team.
-- idam-pr.service.redirect_uri: this is the application callback URL where IDAM will send back the authentication code 
+match the label your service appears with in IDAM Admin Console. If you are not sure what it needs to be set to, 
+you can try and find your service in the list of services in IDAM AAT by going to: https://idam-api.aat.platform.hmcts.net/services. Look for the label value that matches your service, then use that as idam-pr.service.name. If still unsure, please contact IDAM team at #sidam-team.
+- idam-pr.service.redirect_uri: this is the application callback URL where IDAM will send back the authentication code. If you want to find out what redirect URIs are currently registered for your service in AAT, you can find out by going to https://idam-api.aat.platform.hmcts.net/agents/[service_oauth2_client_id] (you can find service_oauth2_client_id in the response of the get-services request above).
 - SERVICE_FQDN - is injected by Jenkins and values file templated before passing to Helm.
 
 ## Default values.yaml

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ idam-pr:
 - idam-pr.service.name: name of the service as configured in IDAM. It is unique per service per environment and will 
 match the label your service appears with in IDAM Admin Console. If you are not sure what it needs to be set to, 
 you can try and find your service in the list of services in IDAM AAT by going to: https://idam-api.aat.platform.hmcts.net/services. Look for the label value that matches your service, then use that as idam-pr.service.name. If still unsure, please contact IDAM team at #sidam-team.
-- idam-pr.service.redirect_uri: this is the application callback URL where IDAM will send back the authentication code. If you want to find out what redirect URIs are currently registered for your service in AAT, you can find out by going to https://idam-api.aat.platform.hmcts.net/agents/[service_oauth2_client_id] (you can find service_oauth2_client_id in the response of the get-services request above).
+- idam-pr.service.redirect_uri: this is the application callback URL where IDAM will send back the authentication code. If you want to find out what redirect URIs are currently registered for your service in AAT, you can do it by going to https://idam-api.aat.platform.hmcts.net/agents/[service_oauth2_client_id] (you can find service_oauth2_client_id in the response of the get-services request above).
 - SERVICE_FQDN - is injected by Jenkins and values file templated before passing to Helm.
 
 ## Default values.yaml

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ idam-pr:
 *Notes*: 
 - idam-pr.service.name: name of the service as configured in IDAM. It is unique per service per environment and will 
 match the label your service appears with in IDAM Admin Console. If you are not sure what it needs to be set to, 
-you can try and find your service in the list of services in IDAM AAT by going to: https://idam-api.aat.platform.hmcts.net/services. Look for the label value that matches your service, then use that as idam-pr.service.name. If still unsure, please contact IDAM team at #sidam-team.
+you can try and find your service in the list of services in IDAM AAT by going to: https://idam-api.aat.platform.hmcts.net/services. Look for the label value that matches your service, then use that as `idam-pr.service.name`. If still unsure, please contact IDAM team at #sidam-team.
 - idam-pr.service.redirect_uri: this is the application callback URL where IDAM will send back the authentication code. If you want to find out what redirect URIs are currently registered for your service in AAT, you can do it by going to https://idam-api.aat.platform.hmcts.net/agents/[service_oauth2_client_id] (you can find service_oauth2_client_id in the response of the get-services request above).
 - SERVICE_FQDN - is injected by Jenkins and values file templated before passing to Helm.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ idam-pr:
 - idam-pr.service.name: name of the service as configured in IDAM. It is unique per service per environment and will 
 match the label your service appears with in IDAM Admin Console. If you are not sure what it needs to be set to, 
 you can try and find your service in the list of services in IDAM AAT by going to: https://idam-api.aat.platform.hmcts.net/services. Look for the label value that matches your service, then use that as `idam-pr.service.name`. If still unsure, please contact IDAM team at #sidam-team.
-- idam-pr.service.redirect_uri: this is the application callback URL where IDAM will send back the authentication code. If you want to find out what redirect URIs are currently registered for your service in AAT, you can do it by going to https://idam-api.aat.platform.hmcts.net/agents/[service_oauth2_client_id] (you can find service_oauth2_client_id in the response of the get-services request above).
+- idam-pr.service.redirect_uri: this is the application callback URL where IDAM will send back the authentication code. If you want to find out what redirect URIs are currently registered for your service in AAT, you can do it by going to https://idam-api.aat.platform.hmcts.net/agents/[service_oauth2_client_id] (you can find `service_oauth2_client_id` in the response of the get-services request above).
 - SERVICE_FQDN - is injected by Jenkins and values file templated before passing to Helm.
 
 ## Default values.yaml

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ dependencies:
       - idam-pr
 ```
 
-values.template.yaml
+values.preview.yaml
 ```yaml
 tags:
   idam-pr: true


### PR DESCRIPTION
`values.template.yaml` is deprecated

values.yaml is the default

value.<aat or preview>.template.yaml

are also supported

This is so that charts work out of the box and we don't get broken charts on install when other teams depend on one