### PR TITLE
Update hook delete policy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ resources:
     type: github
     ref: master
     name: hmcts/cnp-azuredevops-libraries
-    endpoint: 'HMCTS Github'
+    endpoint: 'hmcts'
 
 jobs:
 - job: Validate

--- a/idam-pr/Chart.yaml
+++ b/idam-pr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for dynamic registration of redirect URLs for OAuth2 services in IDAM
 name: idam-pr
-version: 2.0.0
+version: 2.1.0
 icon: https://github.com/hmcts/chart-idam-pr/raw/master/images/icons-helm-50.png
 keywords:
   - idam

--- a/idam-pr/templates/add-redirect-uri.yaml
+++ b/idam-pr/templates/add-redirect-uri.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
+    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed"
 spec:
   template:
     metadata:

--- a/idam-pr/templates/add-redirect-uri.yaml
+++ b/idam-pr/templates/add-redirect-uri.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
 spec:
   template:
     metadata:

--- a/idam-pr/templates/add-redirect-uri.yaml
+++ b/idam-pr/templates/add-redirect-uri.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed"
+    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed,before-hook-creation"
 spec:
   template:
     metadata:

--- a/idam-pr/templates/bin-configmap-add.yaml
+++ b/idam-pr/templates/bin-configmap-add.yaml
@@ -9,10 +9,6 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed"
 data:
   idam-pr-add: |
 {{ include (print .Template.BasePath "/bin/_idam-pr-add.tpl") . | indent 4 }}

--- a/idam-pr/templates/bin-configmap-add.yaml
+++ b/idam-pr/templates/bin-configmap-add.yaml
@@ -4,9 +4,15 @@ kind: ConfigMap
 metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-add
   labels:
-    system: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     type: configuration
-
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-add
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
 data:
   idam-pr-add: |
 {{ include (print .Template.BasePath "/bin/_idam-pr-add.tpl") . | indent 4 }}

--- a/idam-pr/templates/bin-configmap-add.yaml
+++ b/idam-pr/templates/bin-configmap-add.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-add
   labels:
     type: configuration
-    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-add
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-bin-add
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/idam-pr/templates/bin-configmap-add.yaml
+++ b/idam-pr/templates/bin-configmap-add.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
+    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed"
 data:
   idam-pr-add: |
 {{ include (print .Template.BasePath "/bin/_idam-pr-add.tpl") . | indent 4 }}

--- a/idam-pr/templates/bin-configmap-delete.yaml
+++ b/idam-pr/templates/bin-configmap-delete.yaml
@@ -4,9 +4,15 @@ kind: ConfigMap
 metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-delete
   labels:
-    system: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     type: configuration
-
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-del
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  annotations:
+    helm.sh/hook: post-delete
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
 data:
   idam-pr-delete: |
 {{ include (print .Template.BasePath "/bin/_idam-pr-delete.tpl") . | indent 4 }}

--- a/idam-pr/templates/bin-configmap-delete.yaml
+++ b/idam-pr/templates/bin-configmap-delete.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-delete
   labels:
     type: configuration
-    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-del
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-bin-delete
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/idam-pr/templates/bin-configmap-delete.yaml
+++ b/idam-pr/templates/bin-configmap-delete.yaml
@@ -9,10 +9,6 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  annotations:
-    helm.sh/hook: post-delete
-    helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
 data:
   idam-pr-delete: |
 {{ include (print .Template.BasePath "/bin/_idam-pr-delete.tpl") . | indent 4 }}

--- a/idam-pr/templates/bin-configmap-test.yaml
+++ b/idam-pr/templates/bin-configmap-test.yaml
@@ -9,10 +9,6 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed"
 data:
   idam-pr-test: |
 {{ include (print .Template.BasePath "/bin/_idam-pr-test.tpl") . | indent 4 }}

--- a/idam-pr/templates/bin-configmap-test.yaml
+++ b/idam-pr/templates/bin-configmap-test.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-test
   labels:
     type: configuration
-    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-add
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-bin-test
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/idam-pr/templates/bin-configmap-test.yaml
+++ b/idam-pr/templates/bin-configmap-test.yaml
@@ -4,9 +4,15 @@ kind: ConfigMap
 metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-test
   labels:
-    system: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     type: configuration
-
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-add
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
 data:
   idam-pr-test: |
 {{ include (print .Template.BasePath "/bin/_idam-pr-test.tpl") . | indent 4 }}

--- a/idam-pr/templates/bin-configmap-test.yaml
+++ b/idam-pr/templates/bin-configmap-test.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
+    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed"
 data:
   idam-pr-test: |
 {{ include (print .Template.BasePath "/bin/_idam-pr-test.tpl") . | indent 4 }}

--- a/idam-pr/templates/delete-redirect-uri.yaml
+++ b/idam-pr/templates/delete-redirect-uri.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
 spec:
   template:
     metadata:

--- a/idam-pr/templates/delete-redirect-uri.yaml
+++ b/idam-pr/templates/delete-redirect-uri.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed"
+    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed,before-hook-creation"
 spec:
   template:
     metadata:

--- a/idam-pr/templates/delete-redirect-uri.yaml
+++ b/idam-pr/templates/delete-redirect-uri.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
+    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed"
 spec:
   template:
     metadata:

--- a/idam-pr/templates/tests/test-service.yaml
+++ b/idam-pr/templates/tests/test-service.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-test-service
+  labels:
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-bin-test-service
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"

--- a/idam-pr/templates/tests/test-service.yaml
+++ b/idam-pr/templates/tests/test-service.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
   annotations:
     "helm.sh/hook": test-success
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed,before-hook-creation"
 spec:
   volumes:
     - name: container-init

--- a/idam-pr/templates/tests/test-service.yaml
+++ b/idam-pr/templates/tests/test-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-test-service
   annotations:
     "helm.sh/hook": test-success
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 spec:
   volumes:
     - name: container-init

--- a/idam-pr/templates/tests/test-service.yaml
+++ b/idam-pr/templates/tests/test-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-test-service
   annotations:
     "helm.sh/hook": test-success
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
 spec:
   volumes:
     - name: container-init


### PR DESCRIPTION

### Change description ###

- Cleaning up configmaps before running job - job gets stuck in `ContainerCreating` state.
- Helm releases failing because of `Already exists...`

https://github.com/helm/helm/blob/master/docs/charts_hooks.md#automatically-delete-hook-from-previous-release

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
