### PR TITLE
Use before-hook-creation as only delete policy

### DIFF
--- a/idam-pr/Chart.yaml
+++ b/idam-pr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for dynamic registration of redirect URLs for OAuth2 services in IDAM
 name: idam-pr
-version: 2.1.0
+version: 2.1.1
 icon: https://github.com/hmcts/chart-idam-pr/raw/master/images/icons-helm-50.png
 keywords:
   - idam

--- a/idam-pr/templates/add-redirect-uri.yaml
+++ b/idam-pr/templates/add-redirect-uri.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed,before-hook-creation"
+    helm.sh/hook-delete-policy: "before-hook-creation"
 spec:
   template:
     metadata:

--- a/idam-pr/templates/delete-redirect-uri.yaml
+++ b/idam-pr/templates/delete-redirect-uri.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: "hook-succeeded,hook-failed,before-hook-creation"
+    helm.sh/hook-delete-policy: "before-hook-creation"
 spec:
   template:
     metadata:

--- a/idam-pr/templates/tests/test-service.yaml
+++ b/idam-pr/templates/tests/test-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-test-service
+  annotations:
+    helm.sh/hook: test-success
 spec:
   volumes:
     - name: container-init

--- a/idam-pr/templates/tests/test-service.yaml
+++ b/idam-pr/templates/tests/test-service.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
   annotations:
-    "helm.sh/hook": test-success
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed,before-hook-creation"
+    helm.sh/hook: test-success
+    helm.sh/hook-delete-policy: "before-hook-creation"
 spec:
   volumes:
     - name: container-init

--- a/idam-pr/templates/tests/test-service.yaml
+++ b/idam-pr/templates/tests/test-service.yaml
@@ -2,14 +2,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "hmcts.releaseName" . }}-bin-test-service
-  labels:
-    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-bin-test-service
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  annotations:
-    helm.sh/hook: test-success
-    helm.sh/hook-delete-policy: "before-hook-creation"
 spec:
   volumes:
     - name: container-init


### PR DESCRIPTION

### Change description ###

Lots inconsistencies with this change. Local testing is fine. I think its where the first attempt errors but instead of retry `hook-failed` will delete. The other importers - ccd, feature-toggle only use `before-hook-creation`. Should of just went with this - and recognised we have had no issues with these 🤦‍♂ 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
