### PR TITLE
Add annotations to delete configmap

### DIFF
--- a/idam-pr/Chart.yaml
+++ b/idam-pr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for dynamic registration of redirect URLs for OAuth2 services in IDAM
 name: idam-pr
-version: 2.1.1
+version: 2.1.2
 icon: https://github.com/hmcts/chart-idam-pr/raw/master/images/icons-helm-50.png
 keywords:
   - idam

--- a/idam-pr/templates/bin-configmap-delete.yaml
+++ b/idam-pr/templates/bin-configmap-delete.yaml
@@ -9,6 +9,10 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  annotations:
+    helm.sh/hook: post-delete
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: "before-hook-creation"
 data:
   idam-pr-delete: |
 {{ include (print .Template.BasePath "/bin/_idam-pr-delete.tpl") . | indent 4 }}


### PR DESCRIPTION

### Change description ###

HMCTS Demo - I'm stuck:

```
ku get po
NAME                             READY     STATUS              RESTARTS   AGE
cmc-demo-ccd-idam-pr-del-72lf8   0/1       ContainerCreating   0          5h7m
```

ConfigMap it relies on is already gone, so Helm release wont gracefully delete.

This was my original plan - that got lost somewhere along the way.

Post-delete hook for ConfigMap, Pre-delete hook for Job.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
