### PR TITLE
Fix test random user

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
   - template: steps/charts/validate.yaml@cnp-library
     parameters:
       chartName: idam-pr
-      chartReleaseName: chart-idam-pr-ci-test
+      chartReleaseName: chart-idam-pr-ci-timj
       chartNamespace: chart-tests
       helmInstallTimeout: "300"
 

--- a/idam-pr/Chart.yaml
+++ b/idam-pr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for dynamic registration of redirect URLs for OAuth2 services in IDAM
 name: idam-pr
-version: 2.2.2
+version: 2.2.3
 icon: https://github.com/hmcts/chart-idam-pr/raw/master/images/icons-helm-50.png
 keywords:
   - idam

--- a/idam-pr/templates/bin/_idam-pr-test.tpl
+++ b/idam-pr/templates/bin/_idam-pr-test.tpl
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 
-testUsername="james.bond$(($(date +%s%N)/1000))@hmcts.net"
+testRandomUserId=$(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | fold -w ${1:-32} | head -n 1 | awk '{print substr($0,0,15)}')
+
+testUsername="james.bond${testRandomUserId}@hmcts.net"
 testPassword="Agent007"
 
 echo "================================================================"


### PR DESCRIPTION
Luigi Bitonti 22:36
ah :slightly_smiling_face: maybe I’ve found it

the user name randomization is broken on alpine. This is alpine 3.8:
luigis-MBP:kubernetes-course-master luigi$ docker run -it alpine:3.8  sh
/ # echo "$(($(date +%s)/1000))"
1573252
/ # echo "$(($(date +%s%N)/1000))"
1573252
/ # echo "$(($(date +%s)))"
1573252546
this is what instead it should return:
(azure-cli-2.0.67)luigis-MBP:cnp-flux-config luigi$ echo "$(($(gdate +%s%N)/1000))"
1573251581216776
so within 1000 seconds the same user name is returned
when executed on alpine or similar container as the date command there ignores the nanoseconds part of the time spec
so my guess is that there are duplicate usernames generated often
user creation error is not logged and there you go